### PR TITLE
feat: Group内教材の登録・削除機能の実装

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,5 @@
+// API GitHubリンク: https://github.com/HIT-matsumotolab/HelloC_API
+
 import {BrowserRouter as Router, Switch, Route} from 'react-router-dom';
 
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';

--- a/src/components/GroupDetail/GroupDetail.css
+++ b/src/components/GroupDetail/GroupDetail.css
@@ -1,92 +1,100 @@
-.GroupDetailPageTitleFrame{
-    margin-top:20px;
+.GroupDetailPageTitleFrame {
+  margin-top: 20px;
 }
 
-.GroupDetailPageTitle{
-    text-align:left;
-    font-size:30px;
-    padding:10px 30px;
-    padding-left:15px;
-      background: #f4f4f4;/*背景色*/
-    border-left: solid 8px #0659a5;/*左線*/
-    border-bottom: solid 3px #d7d7d7;/*下線*/
+.GroupDetailPageTitle {
+  text-align: left;
+  font-size: 30px;
+  padding: 10px 30px;
+  padding-left: 15px;
+  background: #f4f4f4; /*背景色*/
+  border-left: solid 8px #0659a5; /*左線*/
+  border-bottom: solid 3px #d7d7d7; /*下線*/
 }
 
-.GroupDetailPageTitleFrame-sub{
-    margin-top:20px;
-    margin-bottom:20px;
-    width:80%;
-    position:relative;
-    left:50%;
-    transform:translateX(-50%);
+.GroupDetailPageTitleFrame-sub {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  width: 80%;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
-.GroupDetailPageTitle-sub{
-    text-align:left;
-    font-size:20px;
-    padding:7px 20px;
-    padding-left:15px;
-      background: #f4f4f4;/*背景色*/
-    border-left: solid 8px #ff47ac;/*左線*/
-    border-bottom: solid 3px #d7d7d7;/*下線*/
+.GroupDetailPageTitle-sub {
+  text-align: left;
+  font-size: 20px;
+  padding: 7px 20px;
+  padding-left: 15px;
+  background: #f4f4f4; /*背景色*/
+  border-left: solid 8px #ff47ac; /*左線*/
+  border-bottom: solid 3px #d7d7d7; /*下線*/
 }
 
-.GroupDetailFrame{
-    position:relative;
-    left:50%;
-    transform:translateX(-50%);
-    width:85%;
-    margin-bottom:50px;
-    background-color:antiquewhite;
-    border:solid 1px rgb(170, 169, 169);
-    padding-top:20px;
-    padding-bottom:20px;
-    box-shadow: 5px 5px 5px #00000040;
-    z-index:1;
+.GroupDetailFrame {
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 85%;
+  margin-bottom: 50px;
+  background-color: antiquewhite;
+  border: solid 1px rgb(170, 169, 169);
+  padding-top: 20px;
+  padding-bottom: 20px;
+  box-shadow: 5px 5px 5px #00000040;
+  z-index: 1;
 }
 
-.GroupDetailTopGrid{
-    padding:0 10px;
-    padding-bottom:20px;
-    display:grid;
-    grid-template-columns:repeat(2,1fr);
-    grid-row-gap:20px;
+.GroupDetailTopGrid {
+  padding: 0 10px;
+  padding-bottom: 20px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-row-gap: 20px;
 }
 
-.GroupDetailBottom{
-    padding:0 10px;
-    padding-top:20px;
+.GroupDetailBottom {
+  padding: 0 10px;
+  padding-top: 20px;
 }
 
-.GroupDetailTextRange{
-    margin:10px 10px;
-    font-size:16px;
-    letter-spacing:1px;
-    line-height:2;
-    margin-bottom:0;
+.GroupDetailTextRange {
+  margin: 10px 10px;
+  font-size: 16px;
+  letter-spacing: 1px;
+  line-height: 2;
+  margin-bottom: 0;
 }
 
-.editGroupDetailButtonFrame{
-    margin-top:50px;
-    text-align:right;
-    width:80%;
-    position:relative;
-    left:50%;
-    transform:translateX(-50%);
+.editGroupDetailButtonFrame {
+  margin-top: 50px;
+  text-align: right;
+  width: 80%;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
-.editGroupDetailButton{
-    display:inline !important;
-    font-size:18px !important;
-    margin-bottom:-5px !important;
-    background-color:#ddd;
-    padding:5px 20px !important;
-    /* padding-bottom:40px !important; */
-    box-shadow: 5px 5px 5px #00000040 !important;
-    cursor:pointer;
-    /* transition:margin-bottom .2s !important; */
+.editGroupDetailButton {
+  display: inline !important;
+  font-size: 18px !important;
+  margin-bottom: -5px !important;
+  background-color: #ddd;
+  padding: 5px 20px !important;
+  /* padding-bottom:40px !important; */
+  box-shadow: 5px 5px 5px #00000040 !important;
+  cursor: pointer;
+  /* transition:margin-bottom .2s !important; */
 }
 /* 
 .editGroupDetailButton:hover{
     margin-bottom:-20px !important;
 } */
+
+.TMEditButtonFrameInGroup {
+  padding: 0 20px;
+  display: grid;
+  grid-template-columns: 40% 20% 20%;
+  justify-content: center;
+  grid-column-gap: 20px;
+}


### PR DESCRIPTION
# 概要
- feat: Group内教材の登録・削除機能を作成
- Selectboxに現在作成されている教材一覧を表示
- Selectboxからグループに登録もしくは削除したい教材を選択し、ボタンから実行

# デモ映像
https://user-images.githubusercontent.com/65604109/142729012-984819dc-6eef-4794-979f-2d8359a16ec0.mov

